### PR TITLE
Support passing options to vuetify

### DIFF
--- a/src/decorators/withVuetify.js
+++ b/src/decorators/withVuetify.js
@@ -22,10 +22,10 @@ export const VuetifyPlugin = {
 export const withVuetify = makeDecorator({
   name: 'withVuetify',
   parameterName: 'vuetify',
-  wrapper: (Story, context, { parameters = {} }) => {
+  wrapper: (Story, context, { options = {} }) => {
     VuetifyPlugin.install()
 
-    const vuetify = new Vuetify(deepmerge({}, parameters))
+    const vuetify = new Vuetify(deepmerge({}, options))
     const WrappedComponent = Story(context)
 
     return Vue.extend({


### PR DESCRIPTION
This is an attempt to fix #1. From what I tested, if you use 

```
export const decorators = [
  withVuetify(opts),
];
```

where `opts` is a Vuetify configuration dictionary, this is stored in `options` and not in `parameters`. 
